### PR TITLE
Update train_meta_model_combine.py

### DIFF
--- a/train_meta_model_combine.py
+++ b/train_meta_model_combine.py
@@ -474,7 +474,5 @@ if __name__ == '__main__':
     training_time = time.perf_counter() - time_start
     print('Total training time', training_time)
 
-    if not args.early_stop:
-        checkpoint(0, args.epoch)
     if args.name in ['CIFAR10_miss', 'CIFAR100_miss', 'MNIST_miss']:
         checkpoint(0, args.epoch)


### PR DESCRIPTION
Running the train_meta_model_combine.py 

**Example**
```
python train_meta_model_combine.py --base_model='WideResNet_BaseModel' --meta_model='WideResNet_MetaModel_combine' --name='CIFAR100_OOD' --dataset='CIFAR100' --lr=1e-2 --seed_trail=0 --decay=1e-4 --epoch=1 --lambda_KL=1e-3
```

would result in
```
Traceback (most recent call last):
  File "/meta_dirichlet/PosthocUQ/train_meta_model_combine.py", line 477, in <module>
    if not args.early_stop:
AttributeError: 'Namespace' object has no attribute 'early_stop'
```

As the `early_stop`  argument is not declared during the argparse.

This change will remove lines 477 and 478 from `train_meta_model_combine.py` file, that has unused function calls.